### PR TITLE
chore: add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SymmetrySyndicate/racetrack


### PR DESCRIPTION
Create a `CODEOWNERS` file to assign default reviewers